### PR TITLE
Fixed the bug in the intro.md file

### DIFF
--- a/documentation/docs/intro.md
+++ b/documentation/docs/intro.md
@@ -18,7 +18,7 @@ The following functionalities are currently supported :
 
 ## Workflows
 
-![Project Workflows](/workflows.png)
+![Project Workflows](/img/workflows.png)
 
 ## Installation and Usage
 


### PR DESCRIPTION
On running the development live server for Documentation:

This error shows up:

ERROR in ./docs/intro.md

Module build failed (from ./node_modules/@docusaurus/mdx-loader/lib/index.js):
Error: Image static/workflows.png used in docs/intro.md not found.
    at getImageAbsolutePath (/home/divyanshu/Desktop/Github/GSOC/NFT-Toolbox/documentation/node_modules/@docusaurus/mdx-loader/lib/remark/transformImage/index.js:71:19)
    at async processImageNode (/home/divyanshu/Desktop/Github/GSOC/NFT-Toolbox/documentation/node_modules/@docusaurus/mdx-loader/lib/remark/transformImage/index.js:98:23)
    at async Promise.all (index 0)
    at async /home/divyanshu/Desktop/Github/GSOC/NFT-Toolbox/documentation/node_modules/@docusaurus/mdx-loader/lib/remark/transformImage/index.js:110:9

The path pointing to the image was not correct, So I fixed it