### PR TITLE
dynamic SvgNft Support

### DIFF
--- a/docs/Contracts/SvgnftContract.sol
+++ b/docs/Contracts/SvgnftContract.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.8;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import "base64-sol/base64.sol";
+import "hardhat/console.sol";
+
+error ERC721Metadata__URI_QueryFor_NonExistentToken();
+
+contract SvgNft is ERC721, Ownable {
+    uint256 private s_tokenCounter;
+    string private s_ImageURI;
+
+    mapping(uint256 => int256) private s_tokenIdToHighValues;
+    event CreatedNFT(uint256 indexed tokenId, int256 highValue);
+
+    constructor(string memory Svg) ERC721("Dynamic SVG NFT", "DSN") {
+        s_tokenCounter = 0;
+        s_ImageURI = svgToImageURI(Svg);
+    }
+
+    function safeMintNFT(int256 highValue) public {
+        _safeMint(msg.sender, s_tokenCounter);
+        s_tokenCounter = s_tokenCounter + 1;
+        emit CreatedNFT(s_tokenCounter, highValue);
+    }
+
+    // You could also just upload the raw SVG and have solildity convert it!
+    function svgToImageURI(
+        string memory svg
+    ) public pure returns (string memory) {
+        // example:
+        // '<svg width="500" height="500" viewBox="0 0 285 350" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill="black" d="M150,0,L75,200,L225,200,Z"></path></svg>'
+        // would return ""
+        string memory baseURL = "data:image/svg+xml;base64,";
+        string memory svgBase64Encoded = Base64.encode(
+            bytes(string(abi.encodePacked(svg)))
+        );
+        return string(abi.encodePacked(baseURL, svgBase64Encoded));
+    }
+
+    function _baseURI() internal pure override returns (string memory) {
+        return "data:application/json;base64,";
+    }
+
+    function tokenURI(
+        uint256 tokenId
+    ) public view virtual override returns (string memory) {
+        if (!_exists(tokenId)) {
+            revert ERC721Metadata__URI_QueryFor_NonExistentToken();
+        }
+
+        string memory imageURI = s_ImageURI;
+
+        return
+            string(
+                abi.encodePacked(
+                    _baseURI(),
+                    Base64.encode(
+                        bytes(
+                            abi.encodePacked(
+                                '{"name":"',
+                                name(), // You can add whatever name here
+                                '", "description":"An NFT that changes based on the Chainlink Feed", ',
+                                '"attributes": [{"trait_type": "coolness", "value": 100}], "image":"',
+                                imageURI,
+                                '"}'
+                            )
+                        )
+                    )
+                )
+            );
+    }
+
+    function getSVG() public view returns (string memory) {
+        return s_ImageURI;
+    }
+
+    function getTokenCounter() public view returns (uint256) {
+        return s_tokenCounter;
+    }
+}

--- a/docs/Contracts/SvgnftContract.sol
+++ b/docs/Contracts/SvgnftContract.sol
@@ -14,14 +14,14 @@ contract SvgNft is ERC721, Ownable {
     string private s_ImageURI;
 
     mapping(uint256 => int256) private s_tokenIdToHighValues;
-    event CreatedNFT(uint256 indexed tokenId, int256 highValue);
+    event CreatedNFT(uint256 indexed tokenId);
 
     constructor(string memory Svg) ERC721("Dynamic SVG NFT", "DSN") {
         s_tokenCounter = 0;
         s_ImageURI = svgToImageURI(Svg);
     }
 
-    function safeMintNFT(int256 highValue) public {
+    function safeMintNFT() public {
         _safeMint(msg.sender, s_tokenCounter);
         s_tokenCounter = s_tokenCounter + 1;
         emit CreatedNFT(s_tokenCounter, highValue);

--- a/examples/abi.json
+++ b/examples/abi.json
@@ -1,8 +1,19 @@
 [
 	{
-		"inputs": [],
+		"inputs": [
+			{
+				"internalType": "string",
+				"name": "Svg",
+				"type": "string"
+			}
+		],
 		"stateMutability": "nonpayable",
 		"type": "constructor"
+	},
+	{
+		"inputs": [],
+		"name": "ERC721Metadata__URI_QueryFor_NonExistentToken",
+		"type": "error"
 	},
 	{
 		"anonymous": false,
@@ -55,6 +66,56 @@
 		"type": "event"
 	},
 	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "to",
+				"type": "address"
+			},
+			{
+				"internalType": "uint256",
+				"name": "tokenId",
+				"type": "uint256"
+			}
+		],
+		"name": "approve",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "uint256",
+				"name": "tokenId",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"internalType": "int256",
+				"name": "highValue",
+				"type": "int256"
+			}
+		],
+		"name": "CreatedNFT",
+		"type": "event"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "int256",
+				"name": "highValue",
+				"type": "int256"
+			}
+		],
+		"name": "mintNft",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
 		"anonymous": false,
 		"inputs": [
 			{
@@ -72,6 +133,82 @@
 		],
 		"name": "OwnershipTransferred",
 		"type": "event"
+	},
+	{
+		"inputs": [],
+		"name": "renounceOwnership",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "from",
+				"type": "address"
+			},
+			{
+				"internalType": "address",
+				"name": "to",
+				"type": "address"
+			},
+			{
+				"internalType": "uint256",
+				"name": "tokenId",
+				"type": "uint256"
+			}
+		],
+		"name": "safeTransferFrom",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "from",
+				"type": "address"
+			},
+			{
+				"internalType": "address",
+				"name": "to",
+				"type": "address"
+			},
+			{
+				"internalType": "uint256",
+				"name": "tokenId",
+				"type": "uint256"
+			},
+			{
+				"internalType": "bytes",
+				"name": "data",
+				"type": "bytes"
+			}
+		],
+		"name": "safeTransferFrom",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "operator",
+				"type": "address"
+			},
+			{
+				"internalType": "bool",
+				"name": "approved",
+				"type": "bool"
+			}
+		],
+		"name": "setApprovalForAll",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
 	},
 	{
 		"anonymous": false,
@@ -102,6 +239,11 @@
 		"inputs": [
 			{
 				"internalType": "address",
+				"name": "from",
+				"type": "address"
+			},
+			{
+				"internalType": "address",
 				"name": "to",
 				"type": "address"
 			},
@@ -111,7 +253,20 @@
 				"type": "uint256"
 			}
 		],
-		"name": "approve",
+		"name": "transferFrom",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "newOwner",
+				"type": "address"
+			}
+		],
+		"name": "transferOwnership",
 		"outputs": [],
 		"stateMutability": "nonpayable",
 		"type": "function"
@@ -149,6 +304,32 @@
 				"internalType": "address",
 				"name": "",
 				"type": "address"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "getSVG",
+		"outputs": [
+			{
+				"internalType": "string",
+				"name": "",
+				"type": "string"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "getTokenCounter",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
 			}
 		],
 		"stateMutability": "view",
@@ -224,95 +405,6 @@
 		"type": "function"
 	},
 	{
-		"inputs": [],
-		"name": "renounceOwnership",
-		"outputs": [],
-		"stateMutability": "nonpayable",
-		"type": "function"
-	},
-	{
-		"inputs": [
-			{
-				"internalType": "address",
-				"name": "to",
-				"type": "address"
-			}
-		],
-		"name": "safeMint",
-		"outputs": [],
-		"stateMutability": "nonpayable",
-		"type": "function"
-	},
-	{
-		"inputs": [
-			{
-				"internalType": "address",
-				"name": "from",
-				"type": "address"
-			},
-			{
-				"internalType": "address",
-				"name": "to",
-				"type": "address"
-			},
-			{
-				"internalType": "uint256",
-				"name": "tokenId",
-				"type": "uint256"
-			}
-		],
-		"name": "safeTransferFrom",
-		"outputs": [],
-		"stateMutability": "nonpayable",
-		"type": "function"
-	},
-	{
-		"inputs": [
-			{
-				"internalType": "address",
-				"name": "from",
-				"type": "address"
-			},
-			{
-				"internalType": "address",
-				"name": "to",
-				"type": "address"
-			},
-			{
-				"internalType": "uint256",
-				"name": "tokenId",
-				"type": "uint256"
-			},
-			{
-				"internalType": "bytes",
-				"name": "data",
-				"type": "bytes"
-			}
-		],
-		"name": "safeTransferFrom",
-		"outputs": [],
-		"stateMutability": "nonpayable",
-		"type": "function"
-	},
-	{
-		"inputs": [
-			{
-				"internalType": "address",
-				"name": "operator",
-				"type": "address"
-			},
-			{
-				"internalType": "bool",
-				"name": "approved",
-				"type": "bool"
-			}
-		],
-		"name": "setApprovalForAll",
-		"outputs": [],
-		"stateMutability": "nonpayable",
-		"type": "function"
-	},
-	{
 		"inputs": [
 			{
 				"internalType": "bytes4",
@@ -329,6 +421,25 @@
 			}
 		],
 		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "string",
+				"name": "svg",
+				"type": "string"
+			}
+		],
+		"name": "svgToImageURI",
+		"outputs": [
+			{
+				"internalType": "string",
+				"name": "",
+				"type": "string"
+			}
+		],
+		"stateMutability": "pure",
 		"type": "function"
 	},
 	{
@@ -361,42 +472,6 @@
 			}
 		],
 		"stateMutability": "view",
-		"type": "function"
-	},
-	{
-		"inputs": [
-			{
-				"internalType": "address",
-				"name": "from",
-				"type": "address"
-			},
-			{
-				"internalType": "address",
-				"name": "to",
-				"type": "address"
-			},
-			{
-				"internalType": "uint256",
-				"name": "tokenId",
-				"type": "uint256"
-			}
-		],
-		"name": "transferFrom",
-		"outputs": [],
-		"stateMutability": "nonpayable",
-		"type": "function"
-	},
-	{
-		"inputs": [
-			{
-				"internalType": "address",
-				"name": "newOwner",
-				"type": "address"
-			}
-		],
-		"name": "transferOwnership",
-		"outputs": [],
-		"stateMutability": "nonpayable",
 		"type": "function"
 	}
 ]

--- a/examples/mint.ts
+++ b/examples/mint.ts
@@ -23,7 +23,7 @@ const demoMintNFT = async () => {
 	console.log("Balance: ", bal.toString());
 
 	console.log("Minting New Token");
-	const tx = await nftToolbox.writeContract("safeMint", [address]);
+	const tx = await nftToolbox.writeContract("safeMintNFT", [address]);
 	await tx.wait();
 
 	bal = await nftToolbox.readContract("balanceOf", [address]);


### PR DESCRIPTION
I have integrated the SVG data directly into the metadata of the NFT. This means that the image data is stored on-chain, which solves the issue of relying on external IPFS nodes. Additionally, this change should improve the overall user experience since the images should load more quickly and reliably

1. The Smartcontract that modified can create a dynamic SVG NFT (non-fungible token) using the ERC721 standard.
2.  `safeMintNFT`: This function can be called by anyone to mint a new NFT. it emits a CreatedNFT event with the tokenID. The s_tokenCounter variable is incremented to keep track of the total number of tokens.
3.  `svgToImageURI` : This function takes an SVG string as input and returns a data URI for the image version of the SVG. It first encodes the SVG data as a base64 string using the Base64.encode function from the base64.sol library. Then it constructs a data URI by concatenating the base URL "data:image/svg+xml;base64," with the base64-encoded SVG data.
4. `tokenURI`: This function is overridden to return a JSON metadata string for a given token ID. It first checks if the token exists using the _exists function provided by the ERC721 standard. Then it constructs a JSON string that includes the name, description, attributes, and image URI for the NFT.





