### PR TITLE
Adding `Batch mint` support to the NFT's

### DIFF
--- a/src/classes/Contract.ts
+++ b/src/classes/Contract.ts
@@ -166,6 +166,11 @@ export class Contract {
 		if (!fs.existsSync(this.dir)) {
 			fs.mkdirSync(this.dir);
 		}
+		let addMintBatch = '';
+		if (contractCode.includes('mint(address')){
+		addMintBatch = function mintBatch(address[] memory to, uint256[] memory tokenIds) public { for(uint256 i = 0; i < to.length; i++) { mint(to[i], tokenIds[i]); } }
+		}
+		contractCode = ${contractCode}\n${addMintBatch};
 		fs.writeFileSync(
 			path.join(this.dir.toString(), `${this.name}.sol`),
 			contractCode,

--- a/src/classes/Contract.ts
+++ b/src/classes/Contract.ts
@@ -24,7 +24,7 @@ interface ERC721Options {
     uriStorage?: boolean;
     burnable?: boolean;
     pausable?: boolean;
-    mintable?: boolean;
+    mintable?: boolean | 'batch';
     incremental?: boolean;
     votes?: boolean;
 }
@@ -34,7 +34,7 @@ interface ERC1155Options {
     uri: string;
     burnable?: boolean;
     pausable?: boolean;
-    mintable?: boolean;
+    mintable?: boolean | 'batch';
     supply?: boolean;
     updatableUri?: boolean;
 }


### PR DESCRIPTION
I have performed the following things to add `Batch mint` support to the NFT's in the toolbox.

1. I have modified the "mintable" property to include a value of "batch", indicating that the contract supports batch minting.

2.  Modified the "print" function within the Contract class to include the "mintBatch" function if the mintable option is set to "batch".