### PR TITLE
Give users proper info of accepted currencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,11 @@ An npm package for seamless integration of all NFT related functionalities in We
     ts-node examples/generate.ts
     ```
 
-    To run Tests, update the required credentials in `tests/test_specs.json` file and run
+    To run Tests, update the required credentials in `tests/test_specs.json` file
+    
+    Note:-  Inorder to find the accepted Currencies by bundler please check here - https://docs.bundlr.network/sdk/using-other-currencies
+    
+    and when all the configs are set you can run
 
     ```
     npm test


### PR DESCRIPTION
Fixes: https://github.com/scorelab/NFT-Toolbox/issues/45

New Users are facing the problem of notable to run the tests, due to not able to find proper documentation from the README.

Link to https://docs.bundlr.network/sdk/using-other-currencies docs is added so they know which currencies they can use for testing.

