### PR TITLE
Docs: Fix broken image link in intro.md

### DIFF
--- a/documentation/docs/intro.md
+++ b/documentation/docs/intro.md
@@ -18,7 +18,7 @@ The following functionalities are currently supported :
 
 ## Workflows
 
-![Project Workflows](/workflows.png)
+![Project Workflows](../static/img/workflows.png)
 
 ## Installation and Usage
 


### PR DESCRIPTION

When setting up the project and running it, an issue is encountered, indicating an error in docs/intro.md. This solution addresses and resolves the issue. 

![image](https://github.com/scorelab/NFT-Toolbox/assets/95535448/6d4c2171-1d86-4618-ab59-6f7b322aa4dd)
