### PR TITLE
Utilize web3Stash Library for Metadata Upload, Deprecating Storage Classes #61

### DIFF
--- a/src/classes/FileStorage.ts
+++ b/src/classes/FileStorage.ts
@@ -1,6 +1,9 @@
 import { PathLike } from "fs";
 import path from "path";
 import { Collection } from "./Collection";
+import { Web3Stash } from 'web3stash'; 
+
+const web3Stash = new Web3Stash();
 
 export abstract class FileStorage {
 	abstract serviceBaseURL: string;

--- a/src/classes/FileStorage.ts
+++ b/src/classes/FileStorage.ts
@@ -23,6 +23,10 @@ export abstract class FileStorage {
     const jsonCID = await web3Stash.uploadJSON(json);
     return jsonCID;
   }
+
+  protected abstract readDirectory(dir: PathLike): any;
+	protected abstract readFile(file: PathLike): any;
+
   async uploadCollection(
     collection: Collection
   ): Promise<{ metadataCID: string; assetCID: string }> {


### PR DESCRIPTION
This PR updates the FileStorage class to utilize the web3Stash library for metadata upload, replacing the previous implementation that utilized storage classes. The uploadDirToService, uploadFileToService, and uploadJSONToService methods are now adapted to interface with web3Stash for seamless metadata uploading. Additionally, the changes ensure compatibility with the existing Collection class and maintain consistency in the metadata upload process across the application.